### PR TITLE
Fix service configuration

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -26,7 +26,7 @@
         </service>
 
         <service id="tmdb.configuration" class="%tmdb.client_configuration.class%" public="false">
-            <argument key="event_dispatcher" type="service" id="event_dispatcher" />
+            <argument type="service" id="event_dispatcher" />
             <argument>%tmdb.options%</argument>
 
             <call method="setCacheHandler">


### PR DESCRIPTION
With symfony/symfony#22185 (^3.3), named keys in service configuration files are no longer silently ignored. Now, the following exception is thrown:
```text
[Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]        
Invalid key "event_dispatcher" found in arguments of method "__construct()" for
service "tmdb.configuration": only integer or $named arguments are allowed.
```

As they keys were ignored anyway, it's safe to remove them. 