### PR TITLE
Add php v7.1 and symfony v3.3 to the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,13 @@ matrix:
       env: [SYMFONY_VERSION="2.8.*"]
     - php: 5.6
       env: [SYMFONY_VERSION="3.0.*"]
+    - php: 5.6
+      env: [SYMFONY_VERSION="3.1.*"]
+    - php: 5.6
+      env: [SYMFONY_VERSION="3.2.*"]
+    - php: 5.6
+      env: [SYMFONY_VERSION="^3.3"]
+
     - php: 7.0
       env: [SYMFONY_VERSION="2.3.*", SYMFONY_EVENT_DISPATCHER_VERSION="2.4.*"]
     - php: 7.0
@@ -37,6 +44,26 @@ matrix:
       env: [SYMFONY_VERSION="2.8.*"]
     - php: 7.0
       env: [SYMFONY_VERSION="3.0.*"]
+    - php: 7.0
+      env: [SYMFONY_VERSION="3.1.*"]
+    - php: 7.0
+      env: [SYMFONY_VERSION="3.2.*"]
+    - php: 7.0
+      env: [SYMFONY_VERSION="^3.3"]
+
+    - php: 7.1
+      env: [SYMFONY_VERSION="2.3.*", SYMFONY_EVENT_DISPATCHER_VERSION="2.4.*"]
+    - php: 7.1
+      env: [SYMFONY_VERSION="^2.8"]
+    - php: 7.1
+      env: [SYMFONY_VERSION="3.0.*"]
+    - php: 7.1
+      env: [SYMFONY_VERSION="3.1.*"]
+    - php: 7.1
+      env: [SYMFONY_VERSION="3.2.*"]
+    - php: 7.1
+      env: [SYMFONY_VERSION="^3.3"]
+
   allow_failures:
     - php: nightly
     - php: hhvm


### PR DESCRIPTION
Extend testing matrix by adding recent versions of symfony (3.1 and up).