### PR TITLE
Implement support for Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ matrix:
       env: [SYMFONY_VERSION="3.2.*", SYMFONY_EVENT_DISPATCHER_VERSION="3.2.*"]
     - php: 7.1
       env: [SYMFONY_VERSION="^3.3", SYMFONY_EVENT_DISPATCHER_VERSION="^3.3"]
+    - php: 7.1
+      env: [SYMFONY_VERSION="^4.0", SYMFONY_EVENT_DISPATCHER_VERSION="^4.0"]
 
   allow_failures:
     - php: nightly

--- a/Resources/config/repositories.xml
+++ b/Resources/config/repositories.xml
@@ -30,83 +30,83 @@
     </parameters>
 
     <services>
-        <service id="tmdb.certification_repository" class="%tmdb.certification_repository.class%">
+        <service id="tmdb.certification_repository" class="%tmdb.certification_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.changes_repository" class="%tmdb.changes_repository.class%">
+        <service id="tmdb.changes_repository" class="%tmdb.changes_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.collection_repository" class="%tmdb.collection_repository.class%">
+        <service id="tmdb.collection_repository" class="%tmdb.collection_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.company_repository" class="%tmdb.company_repository.class%">
+        <service id="tmdb.company_repository" class="%tmdb.company_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.configuration_repository" class="%tmdb.configuration_repository.class%">
+        <service id="tmdb.configuration_repository" class="%tmdb.configuration_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.credits_repository" class="%tmdb.credits_repository.class%">
+        <service id="tmdb.credits_repository" class="%tmdb.credits_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.discover_repository" class="%tmdb.discover_repository.class%">
+        <service id="tmdb.discover_repository" class="%tmdb.discover_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.find_repository" class="%tmdb.find_repository.class%">
+        <service id="tmdb.find_repository" class="%tmdb.find_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.genre_repository" class="%tmdb.genre_repository.class%">
+        <service id="tmdb.genre_repository" class="%tmdb.genre_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.jobs_repository" class="%tmdb.jobs_repository.class%">
+        <service id="tmdb.jobs_repository" class="%tmdb.jobs_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.keyword_repository" class="%tmdb.keyword_repository.class%">
+        <service id="tmdb.keyword_repository" class="%tmdb.keyword_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.list_repository" class="%tmdb.list_repository.class%">
+        <service id="tmdb.list_repository" class="%tmdb.list_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.movie_repository" class="%tmdb.movie_repository.class%">
+        <service id="tmdb.movie_repository" class="%tmdb.movie_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.network_repository" class="%tmdb.network_repository.class%">
+        <service id="tmdb.network_repository" class="%tmdb.network_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.people_repository" class="%tmdb.people_repository.class%">
+        <service id="tmdb.people_repository" class="%tmdb.people_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.review_repository" class="%tmdb.review_repository.class%">
+        <service id="tmdb.review_repository" class="%tmdb.review_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.search_repository" class="%tmdb.search_repository.class%">
+        <service id="tmdb.search_repository" class="%tmdb.search_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.tv_repository" class="%tmdb.tv_repository.class%">
+        <service id="tmdb.tv_repository" class="%tmdb.tv_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.tv_season_repository" class="%tmdb.tv_season_repository.class%">
+        <service id="tmdb.tv_season_repository" class="%tmdb.tv_season_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
 
-        <service id="tmdb.tv_episode_repository" class="%tmdb.tv_episode_repository.class%">
+        <service id="tmdb.tv_episode_repository" class="%tmdb.tv_episode_repository.class%" public="true">
             <argument type="service" id="tmdb.client" />
         </service>
     </services>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,7 +16,7 @@
     </parameters>
 
     <services>
-        <service id="tmdb.client" class="%tmdb.client.class%">
+        <service id="tmdb.client" class="%tmdb.client.class%" public="true">
             <argument type="service" id="tmdb.api_token" />
             <argument type="service" id="tmdb.configuration" />
         </service>

--- a/Tests/DependencyInjection/TmdbSymfonyExtensionTest.php
+++ b/Tests/DependencyInjection/TmdbSymfonyExtensionTest.php
@@ -19,12 +19,7 @@ final class TmdbSymfonyExtensionTest extends TestCase
 
         /** @var Container $container */
         $container = $kernel->getContainer();
-        $tmdbServiceIds = array_filter($container->getServiceIds(), function ($id) {
-            return strpos($id, 'tmdb') === 0;
-        });
-
-        foreach ($tmdbServiceIds as $serviceId) {
-            $container->get($serviceId);
-        }
+        $this->assertInstanceOf('Tmdb\Client', $container->get('tmdb.client'));
+        $this->assertInstanceOf('Tmdb\Repository\MovieRepository', $container->get('tmdb.movie_repository'));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,17 +14,17 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "symfony/config": ">=2.7,<4",
-        "symfony/dependency-injection": ">=2.7,<4",
-        "symfony/event-dispatcher": ">=2.7,<4",
-        "symfony/http-kernel": ">=2.7,<4",
+        "symfony/config": ">=2.7,<5",
+        "symfony/dependency-injection": ">=2.7,<5",
+        "symfony/event-dispatcher": ">=2.7,<5",
+        "symfony/http-kernel": ">=2.7,<5",
         "doctrine/doctrine-cache-bundle": "^1.0",
         "php-tmdb/api": "^2.1",
         "twig/twig": "^1.11|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8||^5.0,<5.4",
-        "symfony/framework-bundle": ">=2.7,<4"
+        "symfony/framework-bundle": ">=2.7,<5"
     },
     "autoload": {
         "psr-4": { "Tmdb\\SymfonyBundle\\": "" }


### PR DESCRIPTION
This PR implements support for Symfony 4. To be installable in a Symfony 4 project, php-tmdb/api#172 needs to get merged as well.