### PR TITLE
add title and alt for tests

### DIFF
--- a/Tests/Twig/TmdbExtensionTest.php
+++ b/Tests/Twig/TmdbExtensionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tmdb\SymfonyBundle\Twig;
+namespace Tmdb\SymfonyBundle\Tests\Twig;
 
 use PHPUnit\Framework\TestCase;
 use Tmdb\Client;
@@ -8,6 +8,7 @@ use Tmdb\Helper\ImageHelper;
 use Tmdb\Model\Configuration;
 use Tmdb\Model\Image;
 use Tmdb\Repository\AbstractRepository;
+use Tmdb\SymfonyBundle\Twig\TmdbExtension;
 
 class TmdbExtensionTest extends TestCase
 {

--- a/Tests/Twig/TmdbExtensionTest.php
+++ b/Tests/Twig/TmdbExtensionTest.php
@@ -48,8 +48,8 @@ class TmdbExtensionTest extends TestCase
             ->setVoteCount(666);
 
         $this->assertEquals('//image.tmdb.org/t/p/original/foo.jpg', $extension->getUrl($image));
-        $this->assertEquals(
-            '<img src="//image.tmdb.org/t/p/original/foo.jpg" width="" height="" title="" alt=""/>',
+        $this->assertContains(
+            '<img src="//image.tmdb.org/t/p/original/foo.jpg" width="" height=""',
             $extension->getHtml($image)
         );
         $this->assertEquals('tmdb_extension', $extension->getName());
@@ -96,8 +96,8 @@ class TmdbExtensionTest extends TestCase
             ->setVoteCount(666);
 
         $this->assertEquals('//image.tmdb.org/t/p/original/foo.jpg', $extension->getUrl($image));
-        $this->assertEquals(
-            '<img src="//image.tmdb.org/t/p/original/foo.jpg" width="" height="" title="" alt=""/>',
+        $this->assertContains(
+            '<img src="//image.tmdb.org/t/p/original/foo.jpg" width="" height=""',
             $extension->getHtml($image)
         );
         $this->assertEquals('tmdb_extension', $extension->getName());

--- a/Tests/Twig/TmdbExtensionTest.php
+++ b/Tests/Twig/TmdbExtensionTest.php
@@ -48,7 +48,7 @@ class TmdbExtensionTest extends TestCase
 
         $this->assertEquals('//image.tmdb.org/t/p/original/foo.jpg', $extension->getUrl($image));
         $this->assertEquals(
-            '<img src="//image.tmdb.org/t/p/original/foo.jpg" width="" height="" />',
+            '<img src="//image.tmdb.org/t/p/original/foo.jpg" width="" height="" title="" alt=""/>',
             $extension->getHtml($image)
         );
         $this->assertEquals('tmdb_extension', $extension->getName());
@@ -96,7 +96,7 @@ class TmdbExtensionTest extends TestCase
 
         $this->assertEquals('//image.tmdb.org/t/p/original/foo.jpg', $extension->getUrl($image));
         $this->assertEquals(
-            '<img src="//image.tmdb.org/t/p/original/foo.jpg" width="" height="" />',
+            '<img src="//image.tmdb.org/t/p/original/foo.jpg" width="" height="" title="" alt=""/>',
             $extension->getHtml($image)
         );
         $this->assertEquals('tmdb_extension', $extension->getName());

--- a/Tests/Twig/TmdbExtensionTest.php
+++ b/Tests/Twig/TmdbExtensionTest.php
@@ -48,8 +48,8 @@ class TmdbExtensionTest extends TestCase
             ->setVoteCount(666);
 
         $this->assertEquals('//image.tmdb.org/t/p/original/foo.jpg', $extension->getUrl($image));
-        $this->assertContains(
-            '<img src="//image.tmdb.org/t/p/original/foo.jpg" width="" height=""',
+        $this->assertEquals(
+            '<img src="//image.tmdb.org/t/p/original/foo.jpg" width="" height="" title="" alt=""/>',
             $extension->getHtml($image)
         );
         $this->assertEquals('tmdb_extension', $extension->getName());
@@ -96,8 +96,8 @@ class TmdbExtensionTest extends TestCase
             ->setVoteCount(666);
 
         $this->assertEquals('//image.tmdb.org/t/p/original/foo.jpg', $extension->getUrl($image));
-        $this->assertContains(
-            '<img src="//image.tmdb.org/t/p/original/foo.jpg" width="" height=""',
+        $this->assertEquals(
+            '<img src="//image.tmdb.org/t/p/original/foo.jpg" width="" height="" title="" alt=""/>',
             $extension->getHtml($image)
         );
         $this->assertEquals('tmdb_extension', $extension->getName());

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.3 || ^7.4 || ^8.0",
-        "php-tmdb/api": "^4",
+        "php-tmdb/api": "^4.0.7",
         "symfony/config": "^4.4 || <6",
         "symfony/dependency-injection": "^4.4 || <6",
         "symfony/event-dispatcher": "^4.4 || <6",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "symfony/framework-bundle": "^4.4 || ^5.0",
         "symfony/phpunit-bridge": "^4.4 || ^5",
         "vimeo/psalm": "^4",
-        "php-http/cache-plugin": "^1.7"
+        "php-http/cache-plugin": "^1.7",
+      "ext-json": "*"
     },
     "autoload": {
         "psr-4": { "Tmdb\\SymfonyBundle\\": "" }


### PR DESCRIPTION
api 4.0.7 added title and alt in the Helper getHtml method, so tests were failing.

We could change the test to handle both situations, using assertContains, but that's been deprecated for assertStringContainsString.

So I simply tweaked the test and made the minimum version 4.0.7.

