### PR TITLE
fix phpunit-bridge ^5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,13 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.3 || ^7.4 || ^8.0",
         "php-tmdb/api": "^4",
-        "symfony/config": "^4.3.7 || <6",
-        "symfony/dependency-injection": "^4.3.7 || <6",
-        "symfony/event-dispatcher": "^4.3.7 || <6",
-        "symfony/http-kernel": "^4.3.7 || >=5.1.5",
-        "symfony/phpunit-bridge": "^4.2",
-        "symfony/yaml": "^4.3.7 || ^5.0",
+        "symfony/config": "^4.4 || <6",
+        "symfony/dependency-injection": "^4.4 || <6",
+        "symfony/event-dispatcher": "^4.4 || <6",
+        "symfony/http-kernel": "^4.4.13 || ^5.1.5",
+        "symfony/yaml": "^4.4 || <6",
         "twig/twig": "^2.0 || ^3.0"
     },
     "scripts": {
@@ -38,7 +37,8 @@
         "php-http/guzzle7-adapter": "^0.1",
         "phpstan/phpstan": "^0.12.18",
         "phpunit/phpunit": "^7.5 || ^8.0 || ^9.3",
-        "symfony/framework-bundle": "^4.3.7 || ^5.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "symfony/phpunit-bridge": "^4.4 || ^5",
         "vimeo/psalm": "^4",
         "php-http/cache-plugin": "^1.7"
     },


### PR DESCRIPTION
Quand je veux exécuter `composer require php-tmdb/symfony:^4`, l'erreur était la suivante : 
`Problem 1                                                                                                                                   your root compo
    - Root composer.json requires php-tmdb/symfony 4 -> satisfiable by php-tmdb/symfony[4.0.0].
    - php-tmdb/symfony 4.0.0 requires symfony/phpunit-bridge ^4.2 -> found symfony/phpunit-bridge[v4.2.0, ..., v4.4.33] but it conflicts with  v4.4.33] but it conflicts with your root composer.json require (^5.3).`

Pour résoudre le problème j'ai donc créé une nouvelle branch appelé "phpunit-bridge-fix" qui modifie la branch master et en rajoutant : 
`"require-dev": {
        "symfony/phpunit-bridge": "^4.4 || ^5", 
  }`

